### PR TITLE
Checks if timezone set in php.ini. If not set default is America/Chicago...

### DIFF
--- a/application/bootstrap.php
+++ b/application/bootstrap.php
@@ -12,6 +12,13 @@
  * @license     http://choosealicense.com/licenses/bsd-3-clause/ BSD (3-Clause) License
  */
 
+/**
+* Checks if timezone set in php.ini
+* If not set default is Central Standard Time
+*/
+if(ini_get('date.timezone') == ''){
+    date_default_timezone_set('America/Chicago');
+}
 
 /**
  * Display errors

--- a/application/dataloaders-common.php
+++ b/application/dataloaders-common.php
@@ -17,6 +17,13 @@
  * This file is just some code that was common to all the data-loaders
  */
 
+/**
+* Checks if timezone set in php.ini
+* If not set default is Central Standard Time
+*/
+if(ini_get('date.timezone') == ''){
+    date_default_timezone_set('America/Chicago');
+}
 
 /**
  * Set a $startTime variable to record when we started this script. This time


### PR DESCRIPTION
I've added a few lines that check if the timezone is set. As we discussed over email, my timezone wasn't set when using Mac OS as local dev environment. No timezone = "white screen of death" - no errors displayed. These lines check if it is set, if it is not then _sets_ it to American/Chicago time.
